### PR TITLE
Fixed Symbol.iterator not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "transform-object-rest-spread"
     ],
     "presets": [
-      "es2015"
+      "es2015-subset-loose"
     ]
   },
   "bugs": {
@@ -26,7 +26,7 @@
     "babel-core": "^6.7.6",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015-subset-loose": "^1.0.2",
     "commitizen": "^2.7.6",
     "cz-conventional-changelog": "^1.1.5",
     "expect": "^1.14.0",


### PR DESCRIPTION
Hello!

I try to use your lib for svg shape conversions. My version of NodeJS doesn't support Symbol.iterator. You don't use Symbol in your source file, but Babel use it in compiled files.

It can be fixed by specifying loose: true for this plugin : http://babeljs.io/docs/plugins/transform-es2015-for-of/

The solution I propose is to use the es2015-subset-loose preset instead of the es2015. Tests are 100% OK with this preset on my computer.